### PR TITLE
Update Support links

### DIFF
--- a/jito_geyser/README.md
+++ b/jito_geyser/README.md
@@ -7,7 +7,7 @@ $ pip install jito_geyser
 ```
 
 # Access Token
-Please request access to geyser by emailing support@jito.wtf
+We no longer support access to geyser. Please use 3rd party providers.
 
 # Examples
 

--- a/jito_geyser/pyproject.toml
+++ b/jito_geyser/pyproject.toml
@@ -2,7 +2,7 @@
 name = "jito_geyser"
 version = "0.1.0"
 description = "Jito Labs Geyser Client"
-authors = ["Jito Labs <support@jito.wtf>"]
+authors = ["Jito Labs <https://discord.gg/jito>"]
 readme = "README.md"
 packages = [{ include = "jito_geyser" }]
 

--- a/jito_searcher_client/README.md
+++ b/jito_searcher_client/README.md
@@ -7,7 +7,8 @@ $ pip install jito_searcher_client
 ```
 
 # Keypair Authentication
-Please request access to the block engine by creating a solana keypair and emailing the public key to support@jito.wtf.
+Basic access(5 req/second per IP per region) no longer requires approval. Please visit our [Discord](https://discord.gg/jito) dev channel, if you have other questions.
+If your application requires higher rate limits, please complete this [form](https://forms.gle/8jZmKX1KZA71jXp38)
 
 # Examples
 

--- a/jito_searcher_client/README.md
+++ b/jito_searcher_client/README.md
@@ -7,7 +7,7 @@ $ pip install jito_searcher_client
 ```
 
 # Keypair Authentication
-Basic access(5 req/second per IP per region) no longer requires approval. Please visit our [Discord](https://discord.gg/jito) dev channel, if you have other questions.
+Basic access(5 req/second per region) no longer requires approval. Please visit our [Discord](https://discord.gg/jito) dev channel, if you have other questions.
 If your application requires higher rate limits, please complete this [form](https://forms.gle/8jZmKX1KZA71jXp38)
 
 # Examples

--- a/jito_searcher_client/pyproject.toml
+++ b/jito_searcher_client/pyproject.toml
@@ -2,7 +2,7 @@
 name = "jito_searcher_client"
 version = "0.1.4"
 description = "Jito Labs Python Searcher Client"
-authors = ["Jito Labs <support@jito.wtf>"]
+authors = ["Jito Labs <https://discord.gg/jito>"]
 readme = "README.md"
 packages = [{ include = "jito_searcher_client" }]
 


### PR DESCRIPTION
To remove inbound tickets to PeopleOps, update the usage and support links to route into discord for additional triage. Per discussion with Brian.